### PR TITLE
Fix 'NoSuchMethodError' when there is no clipboardData

### DIFF
--- a/lib/pin_put/pin_put_bloc.dart
+++ b/lib/pin_put/pin_put_bloc.dart
@@ -51,7 +51,7 @@ class PinPutBloc {
   void _checkClipboard() async {
     ClipboardData clipboardData = await Clipboard.getData('text/plain');
 
-    _clp = clipboardData.text;
+    _clp = clipboardData?.text;
     _setButtonState();
   }
 


### PR DESCRIPTION
I've added a null propagation check so `null` passes through to `_setButtonState();`