### PR TITLE
add ability to set container height

### DIFF
--- a/lib/pin_put/pin_put.dart
+++ b/lib/pin_put/pin_put.dart
@@ -22,6 +22,7 @@ class PinPut extends StatefulWidget {
             EdgeInsets.only(left: 10, right: 10, top: 8.0, bottom: 8.0),
         border: OutlineInputBorder(),
         counterText: ''),
+    this.containerHeight = 100.0,
   }) : assert(fieldsCount > 0);
 
   final Function onSubmit;
@@ -47,6 +48,7 @@ class PinPut extends StatefulWidget {
   final bool unFocusWhen;
   final Icon clearButtonIcon;
   final Icon pasteButtonIcon;
+  final double containerHeight;
 
   @override
   PinPutState createState() => PinPutState();

--- a/lib/pin_put/pin_put_state.dart
+++ b/lib/pin_put/pin_put_state.dart
@@ -49,7 +49,7 @@ class PinPutState extends State<PinPut> with WidgetsBindingObserver {
     if (widget.unFocusWhen) _bloc.unFocusAll();
     return Container(
       color: Colors.transparent,
-      height: 100,
+      height: widget.containerHeight,
       child: _generateTextFields(context),
     );
   }


### PR DESCRIPTION
I had a use case to add an errorText below the input fields.
THe container that holds the fields has a fixed size of 100.0 and this leaves a lot of room at the bottom of the container.

This PR introduces containerHeight prop, that allows to set the container height

the default value is 100.0, so should be backward compatible