### PR TITLE
Adding behavior property to the GestureDetector

### DIFF
--- a/lib/pin_put/pin_put_state.dart
+++ b/lib/pin_put/pin_put_state.dart
@@ -144,6 +144,7 @@ class PinPutState extends State<PinPut>
       builder: (BuildContext context, value, Widget? child) {
         return GestureDetector(
           onTap: _handleTap,
+          behavior: HitTestBehavior.translucent,
           child: Row(
             mainAxisSize: widget.mainAxisSize,
             mainAxisAlignment: widget.fieldsAlignment,


### PR DESCRIPTION
I was suffering from a similar issue as described in the following Stackoverflow question:
https://stackoverflow.com/questions/52965799/flutter-gesturedetector-not-working-with-containers-in-stack
The PinPut container wasn't clickable everywhere. Adding the behavior property as per the accepted answer fixed my issue, although I'm not sure exactly why. To my knowledge, this change won't affect the existing behaviour of the PinPut.