### PR TITLE
Fixed example app pin overflow on first pin input

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -132,6 +132,8 @@ class PinPutViewState extends State<PinPutView> {
                 return RoundedButton(
                   title: '$e',
                   onTap: () {
+                    if (_pinPutController.text.length >= 5) return;
+
                     _pinPutController.text = '${_pinPutController.text}$e';
                   },
                 );


### PR DESCRIPTION
Initially, the first pin input from the example app could receive unlimited digits because new digits would always be appended to the end of the existing ones, without checking the current length first. This fixes it.

Thanks for the package!