### PR TITLE
Prevent calling onChange method twice, fixes #40

### DIFF
--- a/lib/pin_put/pin_put_state.dart
+++ b/lib/pin_put/pin_put_state.dart
@@ -52,7 +52,6 @@ class PinPutState extends State<PinPut>
 
   void _textChangeListener() {
     final pin = _controller!.value.text;
-    widget.onChanged?.call(pin);
     if (pin != _textControllerValue!.value) {
       try {
         _textControllerValue!.value = pin;


### PR DESCRIPTION
Since the `onChanged` method is already passed to the `TextFormField`, there is no need to send notifications from the `TextEditingController` listener, since it will react to changes in the focus/сursor of the field.