### PR TITLE
Added scrollPadding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.2.10 -31/05/2022
+- When this widget receives focus and is not completely visible (for example scrolled partially
+  off the screen or overlapped by the keyboard)
+  then it will attempt to make itself visible by scrolling a surrounding [Scrollable], if one is present.
+  This value controls how far from the edges of a [Scrollable] the TextField will be positioned after the scroll.
+  | Property   | Meaning/Default |
+  |------------|:-------:|
+  | scrollPadding  | EdgeInsets.all(20) |
+
+
 ## 2.2.9 -16/05/2022
 - onCompleted mot called
 - Added tests

--- a/lib/src/pinput.dart
+++ b/lib/src/pinput.dart
@@ -85,6 +85,7 @@ class Pinput extends StatefulWidget {
     this.errorBuilder,
     this.errorTextStyle,
     this.pinputAutovalidateMode = PinputAutovalidateMode.onSubmit,
+    this.scrollPadding = const EdgeInsets.all(20),
     Key? key,
   })  : assert(obscuringCharacter.length == 1),
         assert(length > 0),
@@ -308,6 +309,12 @@ class Pinput extends StatefulWidget {
 
   /// Return null if pin is valid or any String otherwise
   final PinputAutovalidateMode pinputAutovalidateMode;
+
+  /// When this widget receives focus and is not completely visible (for example scrolled partially
+  /// off the screen or overlapped by the keyboard)
+  /// then it will attempt to make itself visible by scrolling a surrounding [Scrollable], if one is present.
+  /// This value controls how far from the edges of a [Scrollable] the TextField will be positioned after the scroll.
+  final EdgeInsets scrollPadding;
 
   @override
   State<Pinput> createState() => _PinputState();

--- a/lib/src/pinput_state.dart
+++ b/lib/src/pinput_state.dart
@@ -413,6 +413,7 @@ class _PinputState extends State<Pinput>
           cursorColor: Colors.transparent,
           controller: _effectiveController,
           autofillHints: widget.autofillHints,
+          scrollPadding: widget.scrollPadding,
           selectionWidthStyle: BoxWidthStyle.tight,
           backgroundCursorColor: Colors.transparent,
           selectionHeightStyle: BoxHeightStyle.tight,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: pinput
 description: Pin code input (OTP) text field, iOS SMS autofill, Android SMS autofill One Time Code, Password, Passcode, Captcha, Security, Coupon, Wowcher, 2FA, Two step verification
 homepage: https://github.com/Tkko/Flutter_PinPut
 repository: https://github.com/Tkko/Flutter_PinPut
-version: 2.2.9
+version: 2.2.10
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
## 2.2.10 -31/05/2022
- When this widget receives focus and is not completely visible (for example scrolled partially
  off the screen or overlapped by the keyboard)
  then it will attempt to make itself visible by scrolling a surrounding [Scrollable], if one is present.
  This value controls how far from the edges of a [Scrollable] the TextField will be positioned after the scroll.
  | Property   | Meaning/Default |
  |------------|:-------:|
  | scrollPadding  | EdgeInsets.all(20) |
