### PR TITLE
Add an option to prioritize submittedPinTheme over focusedPinTheme

### DIFF
--- a/lib/src/pinput.dart
+++ b/lib/src/pinput.dart
@@ -54,6 +54,7 @@ class Pinput extends StatefulWidget {
     this.followingPinTheme,
     this.disabledPinTheme,
     this.errorPinTheme,
+    this.prioritizeSubmittedOverFocused = false,
     this.onChanged,
     this.onCompleted,
     this.onSubmitted,
@@ -135,6 +136,9 @@ class Pinput extends StatefulWidget {
 
   /// Theme of the pin in error state
   final PinTheme? errorPinTheme;
+
+  /// Whether to use submittedPinTheme or focusedPinTheme if the pin in focused & submitted state.
+  final bool prioritizeSubmittedOverFocused;
 
   /// If true keyboard will be closed
   final bool closeKeyboardWhenCompleted;

--- a/lib/src/pinput_state.dart
+++ b/lib/src/pinput_state.dart
@@ -481,7 +481,12 @@ class _PinputState extends State<Pinput>
         separatorBuilder: widget.separatorBuilder,
         mainAxisAlignment: widget.mainAxisAlignment,
         children: Iterable<int>.generate(widget.length).map<Widget>((index) {
-          return _PinItem(state: this, index: index);
+          return _PinItem(
+            state: this,
+            index: index,
+            prioritizeSubmittedOverFocused:
+                widget.prioritizeSubmittedOverFocused,
+          );
         }).toList(),
       );
     }

--- a/lib/src/widgets/_pin_item.dart
+++ b/lib/src/widgets/_pin_item.dart
@@ -3,12 +3,17 @@ part of '../pinput.dart';
 class _PinItem extends StatelessWidget {
   final _PinputState state;
   final int index;
+  final bool prioritizeSubmittedOverFocused;
 
-  const _PinItem({required this.state, required this.index});
+  const _PinItem({
+    required this.state,
+    required this.index,
+    required this.prioritizeSubmittedOverFocused,
+  });
 
   @override
   Widget build(BuildContext context) {
-    final pinTheme = _pinTheme(index);
+    final pinTheme = _pinTheme(index, prioritizeSubmittedOverFocused);
 
     return Flexible(
       child: AnimatedContainer(
@@ -32,7 +37,7 @@ class _PinItem extends StatelessWidget {
     );
   }
 
-  PinTheme _pinTheme(int index) {
+  PinTheme _pinTheme(int index, bool prioritizeSubmittedOverFocused) {
     /// Disabled pin or default
     if (!state.isEnabled) {
       return _pinThemeOrDefault(state.widget.disabledPinTheme);
@@ -42,6 +47,13 @@ class _PinItem extends StatelessWidget {
       return _pinThemeOrDefault(state.widget.errorPinTheme);
     }
 
+    final submittedPinTheme =
+        _pinThemeOrDefault(state.widget.submittedPinTheme);
+
+    /// Submitted pin or default
+    if (prioritizeSubmittedOverFocused && index < state.selectedIndex)
+      return submittedPinTheme;
+
     /// Focused pin or default
     if (state.hasFocus &&
         index == state.selectedIndex.clamp(0, state.widget.length - 1)) {
@@ -49,9 +61,7 @@ class _PinItem extends StatelessWidget {
     }
 
     /// Submitted pin or default
-    if (index < state.selectedIndex) {
-      return _pinThemeOrDefault(state.widget.submittedPinTheme);
-    }
+    if (index < state.selectedIndex) return submittedPinTheme;
 
     /// Following pin or default
     return _pinThemeOrDefault(state.widget.followingPinTheme);


### PR DESCRIPTION
When all pins are submitted, last pin can be in both submitted & focused state and currently it'll pick `focusedPinTheme`.

This PR adds an option to pick `submittedPinTheme` instead.

This is necessary so when using some custom shape for the non-submitted pins (i.e just an empty circle), the last pinned can be displayed properly when it's pressed.