### PR TITLE
Bumped `smart_auth` plugin version to 2.0.0:

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  smart_auth: ^1.1.1
+  smart_auth: ^2.0.0
   universal_platform: ^1.0.0+1
 
 dev_dependencies:


### PR DESCRIPTION
This update fixes two important issues:
- Fixed RECEIVER_EXPORTED exception in android SDK 34
- Fix "Namespace not specified" error when upgrading to AGP 8.0