### PR TITLE
Using `Wrap` to allow longer pin codes to wrap into another row

### DIFF
--- a/lib/src/pinput.dart
+++ b/lib/src/pinput.dart
@@ -67,7 +67,7 @@ class Pinput extends StatefulWidget {
     this.senderPhoneNumber,
     this.androidSmsAutofillMethod = AndroidSmsAutofillMethod.none,
     this.listenForMultipleSmsOnAndroid = false,
-    this.mainAxisAlignment = MainAxisAlignment.center,
+    this.mainAxisAlignment = WrapAlignment.center,
     this.crossAxisAlignment = CrossAxisAlignment.start,
     this.pinContentAlignment = Alignment.center,
     this.animationCurve = Curves.easeIn,
@@ -207,8 +207,8 @@ class Pinput extends StatefulWidget {
   /// If null SizedBox(width: 8) will be used
   final JustIndexedWidgetBuilder? separatorBuilder;
 
-  /// Defines how [Pinput] fields are being placed inside [Row]
-  final MainAxisAlignment mainAxisAlignment;
+  /// Defines how [Pinput] fields are being placed inside [Wrap]
+  final WrapAlignment mainAxisAlignment;
 
   /// Defines how [Pinput] and ([errorText] or [errorBuilder]) are being placed inside [Column]
   final CrossAxisAlignment crossAxisAlignment;
@@ -513,10 +513,10 @@ class Pinput extends StatefulWidget {
     );
 
     properties.add(
-      DiagnosticsProperty<MainAxisAlignment>(
+      DiagnosticsProperty<WrapAlignment>(
         'mainAxisAlignment',
         mainAxisAlignment,
-        defaultValue: MainAxisAlignment.center,
+        defaultValue: WrapAlignment.center,
       ),
     );
     properties.add(

--- a/lib/src/pinput_state.dart
+++ b/lib/src/pinput_state.dart
@@ -300,7 +300,7 @@ class _PinputState extends State<Pinput>
     assert(debugCheckHasMaterial(context));
     assert(debugCheckHasMaterialLocalizations(context));
     assert(debugCheckHasDirectionality(context));
-    final isDense = widget.mainAxisAlignment == MainAxisAlignment.center;
+    final isDense = widget.mainAxisAlignment == WrapAlignment.center;
 
     return isDense ? IntrinsicWidth(child: _buildPinput()) : _buildPinput();
   }

--- a/lib/src/widgets/_pin_item.dart
+++ b/lib/src/widgets/_pin_item.dart
@@ -10,24 +10,22 @@ class _PinItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final pinTheme = _pinTheme(index);
 
-    return Flexible(
-      child: AnimatedContainer(
-        height: pinTheme.height,
-        width: pinTheme.width,
-        constraints: pinTheme.constraints,
-        padding: pinTheme.padding,
-        margin: pinTheme.margin,
-        decoration: pinTheme.decoration,
-        alignment: state.widget.pinContentAlignment,
+    return AnimatedContainer(
+      height: pinTheme.height,
+      width: pinTheme.width,
+      constraints: pinTheme.constraints,
+      padding: pinTheme.padding,
+      margin: pinTheme.margin,
+      decoration: pinTheme.decoration,
+      alignment: state.widget.pinContentAlignment,
+      duration: state.widget.animationDuration,
+      curve: state.widget.animationCurve,
+      child: AnimatedSwitcher(
+        switchInCurve: state.widget.animationCurve,
+        switchOutCurve: state.widget.animationCurve,
         duration: state.widget.animationDuration,
-        curve: state.widget.animationCurve,
-        child: AnimatedSwitcher(
-          switchInCurve: state.widget.animationCurve,
-          switchOutCurve: state.widget.animationCurve,
-          duration: state.widget.animationDuration,
-          transitionBuilder: _getTransition,
-          child: _buildFieldContent(index, pinTheme),
-        ),
+        transitionBuilder: _getTransition,
+        child: _buildFieldContent(index, pinTheme),
       ),
     );
   }

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -21,7 +21,7 @@ class _PinputFormField extends FormField<String> {
 
 class _SeparatedRaw extends StatelessWidget {
   final List<Widget> children;
-  final MainAxisAlignment mainAxisAlignment;
+  final WrapAlignment mainAxisAlignment;
   final JustIndexedWidgetBuilder? separatorBuilder;
 
   const _SeparatedRaw({
@@ -35,12 +35,10 @@ class _SeparatedRaw extends StatelessWidget {
   Widget build(BuildContext context) {
     final itemCount = max(0, children.length * 2 - 1);
     final indexedList = [for (int i = 0; i < itemCount; i += 1) i];
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      mainAxisAlignment: mainAxisAlignment,
-      mainAxisSize: mainAxisAlignment == MainAxisAlignment.center
-          ? MainAxisSize.min
-          : MainAxisSize.max,
+    return Wrap(
+      direction: Axis.horizontal,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      alignment: mainAxisAlignment,
       children: indexedList.map((index) {
         final itemIndex = index ~/ 2;
         return index.isEven ? children[itemIndex] : _separator(itemIndex);


### PR DESCRIPTION
We love Pinput's UI and capabilities for entering typical 4-6 length pin codes. However, when faced with a very large key codes which are typical used for activating product keys or gift codes, it forces every input to stay inside a single row... With a 16-length gift code like we use, plus a few `-` to separate the code for easier readability, it makes it impossible to achieve a pleasant UI.

After checking the package code for a bit I experimented with switching the `Row` widget which holds the inputs to a `Wrap`. It holds the same row-like structure up to the point where it needs to shrink. It is also very customizable, which is good for fitting into various UI layouts.

It worked perfectly for us (as you can see in the screenshots below) and we're wondering if this would be a good addition to the package itself. Perhaps adding a 2nd widget or constructor which uses `Wrap` instead of `Row` is preferable, but I think that is up to the package owner to decide. Here are the small changes we did in order to make it work.

<img src="https://github.com/Tkko/Flutter_Pinput/assets/109950863/1a5a7d43-ea62-4a52-ac74-c5a9cd7609fb" width=300px>
<img src="https://github.com/Tkko/Flutter_Pinput/assets/109950863/f1360cb1-916b-4e65-8b3d-8137cb4d738a" width=300px>
