### PR TITLE
Add onFocus to Semantics widget

### DIFF
--- a/lib/src/pinput_state.dart
+++ b/lib/src/pinput_state.dart
@@ -347,6 +347,16 @@ class _PinputState extends State<Pinput>
                   enabled: isEnabled,
                   onTap: widget.readOnly ? null : _semanticsOnTap,
                   onDidGainAccessibilityFocus: handleDidGainAccessibilityFocus,
+                  onFocus: isEnabled
+                      ? () {
+                          if (effectiveFocusNode.canRequestFocus &&
+                              !effectiveFocusNode.hasFocus) {
+                            effectiveFocusNode.requestFocus();
+                          } else if (!widget.readOnly) {
+                            _requestKeyboard();
+                          }
+                        }
+                      : null,
                   child: child,
                 ),
                 child: _gestureDetectorBuilder.buildGestureDetector(


### PR DESCRIPTION
### Summary

This pull request fixes an accessibility issue where the `Pinput` widget would not automatically receive keyboard focus when it received semantic focus. This prevented screen reader users from entering the pin code. 

Unfortunetly this solution doesn't fix all issues and there is still an issue where if the `Pinput` get defocused and focused again using a screen reader the input the user gives is not visible for some reason.

### The Solution

The fix introduces an `onFocus` callback to the `Semantics` widget that wraps the pin input fields. It's similar to how the native `TextField` widget does it.