### PR TITLE
feat: add enableInteractiveSelection parameter

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -58,9 +58,7 @@ class _PinputExampleState extends State<PinputExample> {
     focusNode = FocusNode();
 
     /// In case you need an SMS autofill feature
-    smsRetriever = SmsRetrieverImpl(
-      SmartAuth(),
-    );
+    smsRetriever = SmsRetrieverImpl(SmartAuth());
   }
 
   @override
@@ -104,6 +102,7 @@ class _PinputExampleState extends State<PinputExample> {
             child: Pinput(
               // You can pass your own SmsRetriever implementation based on any package
               // in this example we are using the SmartAuth
+              enableInteractiveSelection: true,
               smsRetriever: smsRetriever,
               controller: pinController,
               focusNode: focusNode,
@@ -177,9 +176,7 @@ class SmsRetrieverImpl implements SmsRetriever {
   Future<String?> getSmsCode() async {
     final signature = await smartAuth.getAppSignature();
     debugPrint('App Signature: $signature');
-    final res = await smartAuth.getSmsCode(
-      useUserConsentApi: true,
-    );
+    final res = await smartAuth.getSmsCode(useUserConsentApi: true);
     if (res.succeed && res.codeFound) {
       return res.code!;
     }

--- a/lib/src/pinput.dart
+++ b/lib/src/pinput.dart
@@ -83,6 +83,7 @@ class Pinput extends StatefulWidget {
     this.showCursor = true,
     this.isCursorAnimationEnabled = true,
     this.enableIMEPersonalizedLearning = false,
+    this.enableInteractiveSelection = false,
     this.enableSuggestions = true,
     this.hapticFeedbackType = HapticFeedbackType.disabled,
     this.closeKeyboardWhenCompleted = true,
@@ -144,6 +145,7 @@ class Pinput extends StatefulWidget {
     this.toolbarEnabled = true,
     this.autofocus = false,
     this.enableIMEPersonalizedLearning = false,
+    this.enableInteractiveSelection = false,
     this.enableSuggestions = true,
     this.hapticFeedbackType = HapticFeedbackType.disabled,
     this.closeKeyboardWhenCompleted = true,
@@ -329,6 +331,15 @@ class Pinput extends StatefulWidget {
   // Defaults to false. Cannot be null.
   final bool enableIMEPersonalizedLearning;
 
+  /// Whether to enable text selection and interactive features like copy/paste.
+  /// When enabled, users can select text, use Ctrl+V to paste, and access context menus.
+  ///
+  /// This is useful for desktop applications where copy/paste is expected behavior.
+  /// On mobile, consider using SMS auto-fill or [onClipboardFound] callback instead.
+  ///
+  /// Defaults to false for security and UX reasons.
+  final bool enableInteractiveSelection;
+
   /// If [showCursor] true the focused field will show passed Widget
   final Widget? cursor;
 
@@ -455,6 +466,13 @@ class Pinput extends StatefulWidget {
         'focusedPinTheme',
         focusedPinTheme,
         defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty<bool>(
+        'enableInteractiveSelection',
+        enableInteractiveSelection,
+        defaultValue: false,
       ),
     );
     properties.add(

--- a/lib/src/pinput_state.dart
+++ b/lib/src/pinput_state.dart
@@ -396,7 +396,7 @@ class _PinputState extends State<Pinput>
           autofillClient: this,
           showSelectionHandles: false,
           rendererIgnoresPointer: true,
-          enableInteractiveSelection: false,
+          enableInteractiveSelection: widget.enableInteractiveSelection,
           enableIMEPersonalizedLearning: widget.enableIMEPersonalizedLearning,
           textInputAction: widget.textInputAction,
           textCapitalization: widget.textCapitalization,


### PR DESCRIPTION
## Description
Adds `enableInteractiveSelection` parameter to enable text selection and copy/paste functionality in Pinput widget.

## Motivation
Currently, Pinput disables interactive selection for security and UX reasons. However, for desktop applications, copy/paste functionality is often expected behavior.

## Changes
- ✅ Add `enableInteractiveSelection` boolean parameter (defaults to false)
- ✅ Update `_buildEditable` method to use the parameter
- ✅ Add documentation and debug properties
- ✅ Maintain backward compatibility

## Testing
- [x] Tested on desktop with Ctrl+V
- [x] Verified default behavior unchanged
- [x] Added example usage

## Breaking Changes
None - defaults to false for backward compatibility.