### PR TITLE
chore: Bump minimum Dart and flutter sdk versions.

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,8 +17,8 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.10.0 <4.0.0'
-  flutter: ">=3.38.1"
+  sdk: '^3.10.0'
+  flutter: '^3.38.1'
 
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,8 +19,8 @@ funding:
   - https://ko-fi.com/flutterman
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
-  flutter: ">=3.7.0"
+  sdk: '^3.9.0'
+  flutter: '^3.35.0'
 
 
 dependencies:


### PR DESCRIPTION
The release of `pinput` 6.0.0 introduces the use of the `hintLocales` property.

This was introduced in Flutter `3.35.0`, which puts a minimum Flutter SDK requirement to `3.35.0` for the package.

If the minimum SDK version is not updated, pub can not automatically pick a supported version of `pinout` based on the projects SDK requirement.

Flutter 3.35.0 changelog: https://docs.flutter.dev/release/release-notes/release-notes-3.35.0
Flutter 3.35.1 has Dart 3.9.0 as min version, [source](https://docs.flutter.dev/install/archive)

Please merge and release this as version `6.0.1` ASAP, enabling automatic package resolving.