### PR TITLE
Add `autovalidateMode` support (Fix #232)

### DIFF
--- a/lib/src/pinput.dart
+++ b/lib/src/pinput.dart
@@ -6,6 +6,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/scheduler.dart';
 
 part 'pinput_state.dart';
 
@@ -95,9 +96,7 @@ class Pinput extends StatefulWidget {
     this.keyboardAppearance,
     this.inputFormatters = const [],
     this.textInputAction,
-    this.autofillHints = const [
-      AutofillHints.oneTimeCode,
-    ],
+    this.autofillHints = const [AutofillHints.oneTimeCode],
     this.obscuringCharacter = '•',
     this.obscuringWidget,
     this.selectionControls,
@@ -112,16 +111,17 @@ class Pinput extends StatefulWidget {
     this.errorBuilder,
     this.errorTextStyle,
     this.pinputAutovalidateMode = PinputAutovalidateMode.onSubmit,
+    this.autovalidateMode = AutovalidateMode.disabled,
     this.scrollPadding = const EdgeInsets.all(20),
     this.contextMenuBuilder = _defaultContextMenuBuilder,
     super.key,
-  })  : assert(obscuringCharacter.length == 1),
-        assert(length > 0),
-        assert(
-          textInputAction != TextInputAction.newline,
-          'Pinput is not multiline',
-        ),
-        _builder = null;
+  }) : assert(obscuringCharacter.length == 1),
+       assert(length > 0),
+       assert(
+         textInputAction != TextInputAction.newline,
+         'Pinput is not multiline',
+       ),
+       _builder = null;
 
   /// Creates a PinPut widget with custom pin item builder
   /// This gives you full control over the pin item widget
@@ -166,38 +166,37 @@ class Pinput extends StatefulWidget {
     this.showErrorWhenFocused = false,
     this.validator,
     this.pinputAutovalidateMode = PinputAutovalidateMode.onSubmit,
+    this.autovalidateMode = AutovalidateMode.disabled,
     this.scrollPadding = const EdgeInsets.all(20),
     this.contextMenuBuilder = _defaultContextMenuBuilder,
     super.key,
-  })  : assert(length > 0),
-        assert(
-          textInputAction != TextInputAction.newline,
-          'Pinput is not multiline',
-        ),
-        _builder = _PinItemBuilder(
-          itemBuilder: builder,
-        ),
-        defaultPinTheme = null,
-        focusedPinTheme = null,
-        submittedPinTheme = null,
-        followingPinTheme = null,
-        disabledPinTheme = null,
-        errorPinTheme = null,
-        preFilledWidget = null,
-        pinContentAlignment = Alignment.center,
-        animationCurve = Curves.easeIn,
-        animationDuration = PinputConstants._animationDuration,
-        pinAnimationType = PinAnimationType.scale,
-        obscureText = false,
-        showCursor = false,
-        isCursorAnimationEnabled = false,
-        slideTransitionBeginOffset = null,
-        cursor = null,
-        obscuringCharacter = '•',
-        obscuringWidget = null,
-        errorText = null,
-        errorBuilder = null,
-        errorTextStyle = null;
+  }) : assert(length > 0),
+       assert(
+         textInputAction != TextInputAction.newline,
+         'Pinput is not multiline',
+       ),
+       _builder = _PinItemBuilder(itemBuilder: builder),
+       defaultPinTheme = null,
+       focusedPinTheme = null,
+       submittedPinTheme = null,
+       followingPinTheme = null,
+       disabledPinTheme = null,
+       errorPinTheme = null,
+       preFilledWidget = null,
+       pinContentAlignment = Alignment.center,
+       animationCurve = Curves.easeIn,
+       animationDuration = PinputConstants._animationDuration,
+       pinAnimationType = PinAnimationType.scale,
+       obscureText = false,
+       showCursor = false,
+       isCursorAnimationEnabled = false,
+       slideTransitionBeginOffset = null,
+       cursor = null,
+       obscuringCharacter = '•',
+       obscuringWidget = null,
+       errorText = null,
+       errorBuilder = null,
+       errorTextStyle = null;
 
   /// Theme of the pin in default state
   final PinTheme? defaultPinTheme;
@@ -421,6 +420,13 @@ class Pinput extends StatefulWidget {
   /// Return null if pin is valid or any String otherwise
   final PinputAutovalidateMode pinputAutovalidateMode;
 
+  /// Controls when the [validator] is automatically invoked.
+  ///
+  /// When set to [AutovalidateMode.onUserInteraction], the validator fires on
+  /// every keystroke so errors appear as the user types. Defaults to
+  /// [AutovalidateMode.disabled] to preserve existing behavior.
+  final AutovalidateMode autovalidateMode;
+
   /// When this widget receives focus and is not completely visible (for example scrolled partially
   /// off the screen or overlapped by the keyboard)
   /// then it will attempt to make itself visible by scrolling a surrounding [Scrollable], if one is present.
@@ -538,8 +544,9 @@ class Pinput extends StatefulWidget {
         defaultValue: null,
       ),
     );
-    properties
-        .add(DiagnosticsProperty<bool>('enabled', enabled, defaultValue: true));
+    properties.add(
+      DiagnosticsProperty<bool>('enabled', enabled, defaultValue: true),
+    );
     properties.add(
       DiagnosticsProperty<bool>(
         'closeKeyboardWhenCompleted',
@@ -666,8 +673,9 @@ class Pinput extends StatefulWidget {
         defaultValue: null,
       ),
     );
-    properties
-        .add(DiagnosticsProperty<bool>('enabled', enabled, defaultValue: true));
+    properties.add(
+      DiagnosticsProperty<bool>('enabled', enabled, defaultValue: true),
+    );
     properties.add(
       DiagnosticsProperty<bool>('readOnly', readOnly, defaultValue: false),
     );
@@ -696,11 +704,7 @@ class Pinput extends StatefulWidget {
       ),
     );
     properties.add(
-      DiagnosticsProperty<bool>(
-        'showCursor',
-        showCursor,
-        defaultValue: true,
-      ),
+      DiagnosticsProperty<bool>('showCursor', showCursor, defaultValue: true),
     );
     properties.add(
       DiagnosticsProperty<String>(
@@ -819,6 +823,13 @@ class Pinput extends StatefulWidget {
         'pinputAutovalidateMode',
         pinputAutovalidateMode,
         defaultValue: PinputAutovalidateMode.onSubmit,
+      ),
+    );
+    properties.add(
+      EnumProperty<AutovalidateMode>(
+        'autovalidateMode',
+        autovalidateMode,
+        defaultValue: AutovalidateMode.disabled,
       ),
     );
     properties.add(

--- a/lib/src/pinput_state.dart
+++ b/lib/src/pinput_state.dart
@@ -38,7 +38,8 @@ class _PinputState extends State<Pinput>
   String? get _errorText => widget.errorText ?? _validatorErrorText;
 
   bool get _canRequestFocus {
-    final NavigationMode mode = MediaQuery.maybeOf(context)?.navigationMode ??
+    final NavigationMode mode =
+        MediaQuery.maybeOf(context)?.navigationMode ??
         NavigationMode.traditional;
     switch (mode) {
       case NavigationMode.traditional:
@@ -74,8 +75,9 @@ class _PinputState extends State<Pinput>
   @override
   void initState() {
     super.initState();
-    _gestureDetectorBuilder =
-        _PinputSelectionGestureDetectorBuilder(state: this);
+    _gestureDetectorBuilder = _PinputSelectionGestureDetectorBuilder(
+      state: this,
+    );
     if (widget.controller != null) {
       _recentControllerValue = widget.controller!.value;
       widget.controller!.addListener(_handleTextEditingControllerChanges);
@@ -213,11 +215,13 @@ class _PinputState extends State<Pinput>
   ) {
     // Selecting part of the text is not allowed.
     final allSelected = selection.start == 0 && selection.end == _currentLength;
-    final lastCharSelected = selection.start == _currentLength - 1 &&
+    final lastCharSelected =
+        selection.start == _currentLength - 1 &&
         selection.end == _currentLength;
     if (!allSelected && !lastCharSelected) {
-      _effectiveController.selection =
-          TextSelection.collapsed(offset: _currentLength);
+      _effectiveController.selection = TextSelection.collapsed(
+        offset: _currentLength,
+      );
     }
 
     switch (Theme.of(context).platform) {
@@ -279,6 +283,22 @@ class _PinputState extends State<Pinput>
   }
 
   String? _validator([String? _]) {
+    // When autovalidateMode triggers validation during FormField's build phase,
+    // skip calling the user's validator entirely and defer to the next frame.
+    // This prevents setState-during-build violations in the user's validator
+    // callback (e.g. calling setState to update a counter).
+    if (SchedulerBinding.instance.schedulerPhase ==
+        SchedulerPhase.persistentCallbacks) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          final res = widget.validator?.call(pin);
+          if (res != _validatorErrorText) {
+            setState(() => _validatorErrorText = res);
+          }
+        }
+      });
+      return _validatorErrorText;
+    }
     final res = widget.validator?.call(pin);
     setState(() => _validatorErrorText = res);
     return res;
@@ -338,6 +358,7 @@ class _PinputState extends State<Pinput>
     return _PinputFormField(
       enabled: isEnabled,
       validator: _validator,
+      autovalidateMode: widget.autovalidateMode,
       initialValue: _effectiveController.text,
       builder: (field) {
         return MouseRegion(
@@ -451,8 +472,9 @@ class _PinputState extends State<Pinput>
           onSelectionChanged: _handleSelectionChanged,
           onSelectionHandleTapped: _handleSelectionHandleTapped,
           readOnly: widget.readOnly || !isEnabled || !widget.useNativeKeyboard,
-          selectionControls:
-              widget.toolbarEnabled ? textSelectionControls : null,
+          selectionControls: widget.toolbarEnabled
+              ? textSelectionControls
+              : null,
           keyboardAppearance:
               widget.keyboardAppearance ?? Theme.of(context).brightness,
         ),
@@ -482,8 +504,9 @@ class _PinputState extends State<Pinput>
 
   void _semanticsOnTap() {
     if (!_effectiveController.selection.isValid) {
-      _effectiveController.selection =
-          TextSelection.collapsed(offset: _effectiveController.text.length);
+      _effectiveController.selection = TextSelection.collapsed(
+        offset: _effectiveController.text.length,
+      );
     }
     _requestKeyboard();
   }
@@ -532,9 +555,10 @@ class _PinputState extends State<Pinput>
 
     return Center(
       child: AnimatedBuilder(
-        animation: Listenable.merge(
-          <Listenable>[_effectiveFocusNode, _effectiveController],
-        ),
+        animation: Listenable.merge(<Listenable>[
+          _effectiveFocusNode,
+          _effectiveController,
+        ]),
         builder: (BuildContext context, Widget? child) {
           final shouldHideErrorContent =
               widget.validator == null && widget.errorText == null;
@@ -546,10 +570,7 @@ class _PinputState extends State<Pinput>
             alignment: Alignment.topCenter,
             child: Column(
               crossAxisAlignment: widget.crossAxisAlignment,
-              children: [
-                onlyFields(),
-                _buildError(),
-              ],
+              children: [onlyFields(), _buildError()],
             ),
           );
         },
@@ -582,9 +603,11 @@ class _PinputState extends State<Pinput>
           padding: const EdgeInsetsDirectional.only(start: 4, top: 8),
           child: Text(
             _errorText!,
-            style: widget.errorTextStyle ??
-                theme.textTheme.titleMedium
-                    ?.copyWith(color: theme.colorScheme.error),
+            style:
+                widget.errorTextStyle ??
+                theme.textTheme.titleMedium?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
           ),
         );
       }
@@ -600,8 +623,9 @@ class _PinputState extends State<Pinput>
 
   @override
   TextInputConfiguration get textInputConfiguration {
-    final List<String>? autofillHints =
-        widget.autofillHints?.toList(growable: false);
+    final List<String>? autofillHints = widget.autofillHints?.toList(
+      growable: false,
+    );
     final AutofillConfiguration autofillConfiguration = autofillHints != null
         ? AutofillConfiguration(
             uniqueIdentifier: autofillId,
@@ -610,7 +634,8 @@ class _PinputState extends State<Pinput>
           )
         : AutofillConfiguration.disabled;
 
-    return _editableText!.textInputConfiguration
-        .copyWith(autofillConfiguration: autofillConfiguration);
+    return _editableText!.textInputConfiguration.copyWith(
+      autofillConfiguration: autofillConfiguration,
+    );
   }
 }

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -10,9 +10,8 @@ class _PinputFormField extends FormField<String> {
     required super.enabled,
     required super.initialValue,
     required super.builder,
-  }) : super(
-          autovalidateMode: AutovalidateMode.disabled,
-        );
+    super.autovalidateMode = AutovalidateMode.disabled,
+  });
 }
 
 class _SeparatedRaw extends StatelessWidget {
@@ -36,10 +35,12 @@ class _SeparatedRaw extends StatelessWidget {
       mainAxisSize: mainAxisAlignment == MainAxisAlignment.center
           ? MainAxisSize.min
           : MainAxisSize.max,
-      children: indexedList.map((index) {
-        final itemIndex = index ~/ 2;
-        return index.isEven ? children[itemIndex] : _separator(itemIndex);
-      }).toList(growable: false),
+      children: indexedList
+          .map((index) {
+            final itemIndex = index ~/ 2;
+            return index.isEven ? children[itemIndex] : _separator(itemIndex);
+          })
+          .toList(growable: false),
     );
   }
 
@@ -61,10 +62,7 @@ class _PinputAnimatedCursor extends StatefulWidget {
   final Widget? cursor;
   final TextStyle? textStyle;
 
-  const _PinputAnimatedCursor({
-    required this.textStyle,
-    required this.cursor,
-  });
+  const _PinputAnimatedCursor({required this.textStyle, required this.cursor});
 
   @override
   State<_PinputAnimatedCursor> createState() => _PinputAnimatedCursorState();

--- a/test/pinput_test.dart
+++ b/test/pinput_test.dart
@@ -94,8 +94,9 @@ void main() {
     testState(0, disabledTheme);
   });
 
-  testWidgets('Should properly handle focused state',
-      (WidgetTester tester) async {
+  testWidgets('Should properly handle focused state', (
+    WidgetTester tester,
+  ) async {
     final focusNode = FocusNode();
     const defaultTheme = PinTheme(decoration: BoxDecoration());
     final focusedTheme = defaultTheme.copyDecorationWith(color: Colors.red);
@@ -124,20 +125,16 @@ void main() {
   });
 
   testWidgets('Should display custom cursor', (WidgetTester tester) async {
-    await tester.pumpApp(
-      const Pinput(
-        autofocus: true,
-        cursor: FlutterLogo(),
-      ),
-    );
+    await tester.pumpApp(const Pinput(autofocus: true, cursor: FlutterLogo()));
 
     await tester.pump();
     expect(find.byType(FlutterLogo), findsOneWidget);
   });
 
   group('onChanged should work properly', () {
-    testWidgets('onChanged should work with controller',
-        (WidgetTester tester) async {
+    testWidgets('onChanged should work with controller', (
+      WidgetTester tester,
+    ) async {
       String? fieldValue;
       int called = 0;
 
@@ -168,8 +165,9 @@ void main() {
       expect(called, 2);
     });
 
-    testWidgets('onChanged should work with controller',
-        (WidgetTester tester) async {
+    testWidgets('onChanged should work with controller', (
+      WidgetTester tester,
+    ) async {
       String? fieldValue;
       int called = 0;
       final TextEditingController controller = TextEditingController();
@@ -206,8 +204,9 @@ void main() {
   });
 
   group('onCompleted should work properly', () {
-    testWidgets('onCompleted works without controller',
-        (WidgetTester tester) async {
+    testWidgets('onCompleted works without controller', (
+      WidgetTester tester,
+    ) async {
       String? fieldValue;
       int called = 0;
 
@@ -274,11 +273,7 @@ void main() {
   testWidgets('onTap is called upon tap', (WidgetTester tester) async {
     int tapCount = 0;
 
-    await tester.pumpApp(
-      Pinput(
-        onTap: () => ++tapCount,
-      ),
-    );
+    await tester.pumpApp(Pinput(onTap: () => ++tapCount));
 
     expect(tapCount, 0);
     await tester.tap(find.byType(EditableText));
@@ -291,16 +286,12 @@ void main() {
     expect(tapCount, 3);
   });
 
-  testWidgets('onTap is not called, field is disabled',
-      (WidgetTester tester) async {
+  testWidgets('onTap is not called, field is disabled', (
+    WidgetTester tester,
+  ) async {
     int tapCount = 0;
 
-    await tester.pumpApp(
-      Pinput(
-        enabled: false,
-        onTap: () => ++tapCount,
-      ),
-    );
+    await tester.pumpApp(Pinput(enabled: false, onTap: () => ++tapCount));
 
     expect(tapCount, 0);
     await tester.tap(find.byType(EditableText), warnIfMissed: false);
@@ -311,11 +302,7 @@ void main() {
   testWidgets('onLongPress is called', (WidgetTester tester) async {
     int tapCount = 0;
 
-    await tester.pumpApp(
-      Pinput(
-        onLongPress: () => ++tapCount,
-      ),
-    );
+    await tester.pumpApp(Pinput(onLongPress: () => ++tapCount));
 
     expect(tapCount, 0);
     await tester.longPress(find.byType(EditableText));
@@ -331,16 +318,163 @@ void main() {
   testWidgets('onSubmitted callback is called', (WidgetTester tester) async {
     String? fieldValue;
 
-    await tester.pumpApp(
-      Pinput(
-        onSubmitted: (value) => fieldValue = value,
-      ),
-    );
+    await tester.pumpApp(Pinput(onSubmitted: (value) => fieldValue = value));
 
     expect(fieldValue, isNull);
 
     await tester.enterText(find.byType(EditableText), '123');
     await tester.testTextInput.receiveAction(TextInputAction.done);
     expect(fieldValue, equals('123'));
+  });
+
+  group('autovalidateMode should work properly', () {
+    testWidgets(
+      'validator is not called while typing when autovalidateMode is disabled',
+      (WidgetTester tester) async {
+        int validatorCalled = 0;
+
+        await tester.pumpApp(
+          Pinput(
+            length: 4,
+            autovalidateMode: AutovalidateMode.disabled,
+            validator: (value) {
+              validatorCalled++;
+              return value == null || value.length < 4 ? 'error' : null;
+            },
+          ),
+        );
+
+        await tester.enterText(find.byType(EditableText), '12');
+        await tester.pump();
+
+        expect(validatorCalled, 0);
+      },
+    );
+
+    testWidgets(
+      'validator is called on every keystroke with onUserInteraction',
+      (WidgetTester tester) async {
+        int validatorCalled = 0;
+
+        await tester.pumpApp(
+          Pinput(
+            length: 4,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            validator: (value) {
+              validatorCalled++;
+              return value == null || value.length < 4 ? 'error' : null;
+            },
+          ),
+        );
+
+        await tester.enterText(find.byType(EditableText), '1');
+        await tester.pump();
+
+        expect(validatorCalled, greaterThan(0));
+      },
+    );
+
+    testWidgets(
+      'error text is displayed after partial entry with onUserInteraction',
+      (WidgetTester tester) async {
+        const errorMessage = 'PIN must be 4 digits';
+
+        await tester.pumpApp(
+          Pinput(
+            length: 4,
+            autofocus: true,
+            showErrorWhenFocused: true,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            validator: (value) =>
+                (value == null || value.length < 4) ? errorMessage : null,
+          ),
+        );
+
+        await tester.enterText(find.byType(EditableText), '12');
+        // Two pumps needed: first runs FormField validation and the deferred
+        // postFrameCallback, second rebuilds _PinputState with the error text.
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text(errorMessage), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'error text disappears when PIN becomes valid with onUserInteraction',
+      (WidgetTester tester) async {
+        const errorMessage = 'PIN must be 4 digits';
+
+        await tester.pumpApp(
+          Pinput(
+            length: 4,
+            autofocus: true,
+            showErrorWhenFocused: true,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            validator: (value) =>
+                (value == null || value.length < 4) ? errorMessage : null,
+          ),
+        );
+
+        await tester.enterText(find.byType(EditableText), '12');
+        await tester.pump();
+        await tester.pump();
+        expect(find.text(errorMessage), findsOneWidget);
+
+        await tester.enterText(find.byType(EditableText), '1234');
+        await tester.pump();
+        await tester.pump();
+        expect(find.text(errorMessage), findsNothing);
+      },
+    );
+
+    testWidgets('omitting autovalidateMode preserves legacy behavior', (
+      WidgetTester tester,
+    ) async {
+      int validatorCalled = 0;
+
+      await tester.pumpApp(
+        Pinput(
+          length: 4,
+          validator: (value) {
+            validatorCalled++;
+            return null;
+          },
+        ),
+      );
+
+      await tester.enterText(find.byType(EditableText), '12');
+      await tester.pump();
+
+      expect(validatorCalled, 0);
+    });
+
+    testWidgets('Pinput.builder respects autovalidateMode', (
+      WidgetTester tester,
+    ) async {
+      int validatorCalled = 0;
+
+      await tester.pumpApp(
+        Pinput.builder(
+          length: 4,
+          autovalidateMode: AutovalidateMode.onUserInteraction,
+          validator: (value) {
+            validatorCalled++;
+            return value == null || value.length < 4 ? 'error' : null;
+          },
+          builder: (context, state) => Container(
+            key: ValueKey(state.index),
+            width: 40,
+            height: 40,
+            color: Colors.blue,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(EditableText), '1');
+      await tester.pump();
+
+      expect(validatorCalled, greaterThan(0));
+    });
   });
 }


### PR DESCRIPTION
Hello @Tkko, thank you for your continuous work on pinput.
I've submitted this PR to fix #232 and introduce the requested autovalidateMode support.

Fix #232

## Problem

Pinput's internal `_PinputFormField` subclasses Flutter's `FormField` but hardcoded
`autovalidateMode: AutovalidateMode.disabled`, making it impossible for callers to
opt into keystroke-level validation.

```dart
// Before
class _PinputFormField extends FormField<String> {
  const _PinputFormField({ ... }) : super(
    autovalidateMode: AutovalidateMode.disabled,  // hardcoded — no way to override
  );
}
```

As a result, `validator` only fired when all digits were entered (`_maybeValidateForm`)
or on explicit form submission. Partial-input errors were silently swallowed.

## Root cause & fix

### Data flow with `onUserInteraction`

```
User keystroke
  → EditableText.onChanged → field.didChange(value)
  → FormField sets _hasInteractedByUser = true, schedules rebuild
  → On rebuild, FormField detects onUserInteraction + interacted → calls _validate()
  → _validate() → _validator() → user validator + setState(_validatorErrorText)
  → Error theme + error text rendered immediately
```

### `_PinputFormField` — forward instead of hardcode

```dart
// After
class _PinputFormField extends FormField<String> {
  const _PinputFormField({
    ...
    super.autovalidateMode = AutovalidateMode.disabled,  // forwarded, default preserved
  });
}
```

### `setState`-during-build hazard

When `AutovalidateMode.onUserInteraction` is active, `FormField.build()` calls
`_validate()` → `_validator()` during the build phase. Since `_validator()` calls
`setState`, this triggers a _setState-during-build_ violation.

Fix: skip the user validator call entirely during `SchedulerPhase.persistentCallbacks`
and defer the full validation to the next frame. A `res != _validatorErrorText` guard
prevents infinite `postFrameCallback → setState → rebuild → postFrameCallback` loops.

```dart
String? _validator([String? _]) {
  if (SchedulerBinding.instance.schedulerPhase ==
      SchedulerPhase.persistentCallbacks) {
    SchedulerBinding.instance.addPostFrameCallback((_) {
      if (mounted) {
        final res = widget.validator?.call(pin);
        if (res != _validatorErrorText) {
          setState(() => _validatorErrorText = res);
        }
      }
    });
    return _validatorErrorText;  // return current error; UI updates next frame
  }
  final res = widget.validator?.call(pin);
  setState(() => _validatorErrorText = res);
  return res;
}
```

## Changed files

| File | Change |
|---|---|
| `lib/src/pinput.dart` | Add `autovalidateMode` field + parameter to both constructors + `debugFillProperties` entry; add `scheduler.dart` import |
| `lib/src/widgets/widgets.dart` | Replace hardcoded `autovalidateMode` with a forwarded named parameter |
| `lib/src/pinput_state.dart` | Pass `autovalidateMode` to `_PinputFormField`; update `_validator()` with build-phase defer logic |
| `test/pinput_test.dart` | Add 6 test cases for the new behavior |

## Usage

```dart
// Existing code — no change required
Pinput(
  validator: (value) => value?.length != 4 ? 'Invalid OTP' : null,
)

// New: real-time validation on every keystroke
Pinput(
  autovalidateMode: AutovalidateMode.onUserInteraction,
  showErrorWhenFocused: true,
  validator: (value) => value?.length != 4 ? 'Invalid OTP' : null,
)
```

## Tests

Six new cases in `group('autovalidateMode should work properly', ...)`:

| Test | What it guards |
|---|---|
| `disabled` — validator not called while typing | Regression: existing callers unaffected |
| `onUserInteraction` — validator called per keystroke | Core feature |
| Error text displayed on partial entry | `_validatorErrorText` + `showErrorState` UI flow |
| Error text disappears when PIN becomes valid | Round-trip: error clears on valid input |
| Omitting `autovalidateMode` preserves legacy behavior | API contract: default is `disabled` |
| `Pinput.builder` also respects the parameter | Both constructors covered |

```
flutter test    # → All tests passed! (18 tests)
flutter analyze # → No issues found!
```

## Backward compatibility

- Default is `AutovalidateMode.disabled` — existing code requires no changes
- `PinputAutovalidateMode` and `pinputAutovalidateMode` are untouched

---

## Demo

https://github.com/user-attachments/assets/e1ddad3c-af8d-412b-b712-1862cbac36e1


<details>
<summary>Verification code (before/after comparison page)</summary>

```dart
import 'package:flutter/material.dart';
import 'package:pinput/pinput.dart';

class AutovalidateComparisonPage extends StatelessWidget {
  const AutovalidateComparisonPage({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      backgroundColor: const Color(0xFFF5F7FA),
      appBar: AppBar(
        backgroundColor: Colors.white,
        elevation: 0,
        centerTitle: true,
        title: const Text(
          'autovalidateMode comparison',
          style: TextStyle(
            fontSize: 18,
            fontWeight: FontWeight.w600,
            color: Color(0xFF1E3C57),
          ),
        ),
      ),
      body: const SingleChildScrollView(
        padding: EdgeInsets.symmetric(horizontal: 24, vertical: 32),
        child: Column(
          crossAxisAlignment: CrossAxisAlignment.stretch,
          children: [
            _SectionCard(
              tag: 'Before',
              tagColor: Color(0xFF9E9E9E),
              title: 'Default (disabled)',
              description: 'Validation runs only when all digits are entered.\n'
                  'No error is shown while typing partial input.',
              child: _LegacyExample(),
            ),
            SizedBox(height: 28),
            _SectionCard(
              tag: 'After',
              tagColor: Color(0xFF17AB90),
              title: 'AutovalidateMode.onUserInteraction',
              description: 'Validation runs on every keystroke.\n'
                  'Errors appear in real time as the user types.',
              child: _NewExample(),
            ),
          ],
        ),
      ),
    );
  }
}

// ── Before ──────────────────────────────────────────────────
class _LegacyExample extends StatefulWidget {
  const _LegacyExample();

  @override
  State<_LegacyExample> createState() => _LegacyExampleState();
}

class _LegacyExampleState extends State<_LegacyExample> {
  final _controller = TextEditingController();
  final _callCount = ValueNotifier<int>(0);

  @override
  void dispose() {
    _controller.dispose();
    _callCount.dispose();
    super.dispose();
  }

  @override
  Widget build(BuildContext context) {
    return Column(
      children: [
        Pinput(
          controller: _controller,
          length: 4,
          defaultPinTheme: _defaultTheme,
          focusedPinTheme: _focusedTheme,
          submittedPinTheme: _submittedTheme,
          errorPinTheme: _errorTheme,
          validator: (value) {
            _callCount.value++;
            return value != '1234' ? 'Correct PIN is 1234' : null;
          },
          errorTextStyle: const TextStyle(color: Colors.redAccent, fontSize: 13),
        ),
        const SizedBox(height: 16),
        ValueListenableBuilder<int>(
          valueListenable: _callCount,
          builder: (_, count, __) => _CallCounter(count: count),
        ),
        const SizedBox(height: 8),
        TextButton.icon(
          onPressed: () {
            _controller.clear();
            _callCount.value = 0;
          },
          icon: const Icon(Icons.refresh, size: 16),
          label: const Text('Reset'),
        ),
      ],
    );
  }
}

// ── After ───────────────────────────────────────────────────
class _NewExample extends StatefulWidget {
  const _NewExample();

  @override
  State<_NewExample> createState() => _NewExampleState();
}

class _NewExampleState extends State<_NewExample> {
  final _controller = TextEditingController();
  final _callCount = ValueNotifier<int>(0);

  @override
  void dispose() {
    _controller.dispose();
    _callCount.dispose();
    super.dispose();
  }

  @override
  Widget build(BuildContext context) {
    return Column(
      children: [
        Pinput(
          controller: _controller,
          length: 4,
          autovalidateMode: AutovalidateMode.onUserInteraction,
          showErrorWhenFocused: true,
          defaultPinTheme: _defaultTheme,
          focusedPinTheme: _focusedTheme,
          submittedPinTheme: _submittedTheme,
          errorPinTheme: _errorTheme,
          validator: (value) {
            _callCount.value++;
            return value != '1234' ? 'Correct PIN is 1234' : null;
          },
          errorTextStyle: const TextStyle(color: Colors.redAccent, fontSize: 13),
        ),
        const SizedBox(height: 16),
        ValueListenableBuilder<int>(
          valueListenable: _callCount,
          builder: (_, count, __) => _CallCounter(count: count),
        ),
        const SizedBox(height: 8),
        TextButton.icon(
          onPressed: () {
            _controller.clear();
            _callCount.value = 0;
          },
          icon: const Icon(Icons.refresh, size: 16),
          label: const Text('Reset'),
        ),
      ],
    );
  }
}

// ── Shared themes ────────────────────────────────────────────
const _borderColor = Color(0x6617AB90);
const _focusedBorderColor = Color(0xFF17AB90);

final _defaultTheme = PinTheme(
  width: 56,
  height: 56,
  textStyle: const TextStyle(fontSize: 20, color: Color(0xFF1E3C57)),
  decoration: BoxDecoration(
    color: Colors.white,
    borderRadius: BorderRadius.circular(12),
    border: Border.all(color: _borderColor),
  ),
);

final _focusedTheme = _defaultTheme.copyDecorationWith(
  border: Border.all(color: _focusedBorderColor, width: 2),
);

final _submittedTheme = _defaultTheme.copyDecorationWith(
  border: Border.all(color: _focusedBorderColor),
);

final _errorTheme = _defaultTheme.copyDecorationWith(
  border: Border.all(color: Colors.redAccent),
);

// ── Widgets ──────────────────────────────────────────────────
class _CallCounter extends StatelessWidget {
  final int count;

  const _CallCounter({required this.count});

  @override
  Widget build(BuildContext context) {
    return Row(
      mainAxisAlignment: MainAxisAlignment.center,
      children: [
        const Icon(Icons.functions, size: 14, color: Color(0xFF888888)),
        const SizedBox(width: 4),
        Text(
          'Validator calls: $count',
          style: const TextStyle(fontSize: 13, color: Color(0xFF888888)),
        ),
      ],
    );
  }
}

class _SectionCard extends StatelessWidget {
  final String tag;
  final Color tagColor;
  final String title;
  final String description;
  final Widget child;

  const _SectionCard({
    required this.tag,
    required this.tagColor,
    required this.title,
    required this.description,
    required this.child,
  });

  @override
  Widget build(BuildContext context) {
    return Container(
      decoration: BoxDecoration(
        color: Colors.white,
        borderRadius: BorderRadius.circular(16),
        boxShadow: const [
          BoxShadow(
            color: Color(0x0F000000),
            blurRadius: 12,
            offset: Offset(0, 4),
          ),
        ],
      ),
      padding: const EdgeInsets.all(24),
      child: Column(
        crossAxisAlignment: CrossAxisAlignment.start,
        children: [
          Row(
            children: [
              Container(
                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
                decoration: BoxDecoration(
                  color: tagColor.withValues(alpha: 0.12),
                  borderRadius: BorderRadius.circular(6),
                ),
                child: Text(
                  tag,
                  style: TextStyle(
                    fontSize: 11,
                    fontWeight: FontWeight.w700,
                    color: tagColor,
                    letterSpacing: 0.5,
                  ),
                ),
              ),
              const SizedBox(width: 8),
              Expanded(
                child: Text(
                  title,
                  style: const TextStyle(
                    fontSize: 14,
                    fontWeight: FontWeight.w600,
                    color: Color(0xFF1E3C57),
                    fontFamily: 'monospace',
                  ),
                ),
              ),
            ],
          ),
          const SizedBox(height: 10),
          Text(
            description,
            style: const TextStyle(
              fontSize: 13,
              color: Color(0xFF666666),
              height: 1.5,
            ),
          ),
          const SizedBox(height: 20),
          Center(child: child),
        ],
      ),
    );
  }
}
```

</details>
