### PR TITLE
fix: bump minimum Flutter SDK to 3.27.0 to fix TapRegionUpCallback not found ( #227,  #229)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ funding:
 
 environment:
   sdk: '>=2.19.0 <4.0.0'
-  flutter: ">=3.7.0"
+  flutter: ">=3.27.0"
 
 
 dependencies:


### PR DESCRIPTION
Hi @Tkko 👋 Thanks again for your continuous work on this package!
I'm submitting this PR to fix the compilation issues reported by users on older Flutter versions.

## Problem

Users on Flutter 3.24.x and earlier encounter a compile-time error when using this package:

```
Error: Type 'TapRegionUpCallback' not found.
lib/src/pinput.dart:461:9: final TapRegionUpCallback? onTapUpOutside;

Error: No named parameter with the name 'onTapUpOutside'.
lib/src/pinput_state.dart:432:11: onTapUpOutside: widget.onTapUpOutside,
```

## Root Cause

`TapRegionUpCallback` and `EditableText.onTapUpOutside` were introduced in **Flutter 3.27.0** via [flutter/flutter#156110](https://github.com/flutter/flutter/pull/156110) — merged on 2024-10-21, included in the Flutter 3.27.0 stable release (tagged 2024-12-10).

The `pubspec.yaml` SDK constraint was `flutter: ">=3.7.0"`, which allowed users on older Flutter versions to install the package and hit this compile error at build time.

### Affected code

| File | Line | Code |
|---|---|---|
| `lib/src/pinput.dart` | 461 | `final TapRegionUpCallback? onTapUpOutside;` |
| `lib/src/pinput_state.dart` | 432 | `onTapUpOutside: widget.onTapUpOutside,` |
| `pubspec.yaml` | 23 | `flutter: ">=3.7.0"` ← too permissive |

## Fix

Raise the minimum Flutter SDK constraint to match the version that introduced the type:

```yaml
# Before
flutter: ">=3.7.0"

# After
flutter: ">=3.27.0"
```

Users on incompatible Flutter versions will now receive a clear version conflict message from the package resolver instead of an opaque compile-time type error.

## ⚠️ Breaking Change / Versioning Note

Bumping the minimum Flutter SDK constraint from 3.7.0 to 3.27.0 is a significant jump. While it correctly reflects the required framework APIs, it acts as a breaking change for users who are still on older Flutter versions.

Depending on your versioning strategy, you might want to consider publishing this change as a major version bump to adhere to semantic versioning and avoid unexpectedly breaking CI pipelines for existing users.

## Alternatives Considered

| Option | Reason rejected |
|---|---|
| Remove `onTapUpOutside` parameter | Breaking change — removes an existing feature |
| Define a local typedef for the callback | Dart has no conditional compilation; the local typedef would conflict with the framework type on Flutter ≥ 3.27.0 |

## Related Issues

- Closes #227
- Closes #229
