### PR TITLE
feat: add showToolbarOnTap option for iOS single-tap context menu

### DIFF
--- a/lib/src/pinput.dart
+++ b/lib/src/pinput.dart
@@ -79,6 +79,7 @@ class Pinput extends StatefulWidget {
     this.readOnly = false,
     this.useNativeKeyboard = true,
     this.toolbarEnabled = true,
+    this.showToolbarOnTap = false,
     this.autofocus = false,
     this.obscureText = false,
     this.showCursor = true,
@@ -145,6 +146,7 @@ class Pinput extends StatefulWidget {
     this.readOnly = false,
     this.useNativeKeyboard = true,
     this.toolbarEnabled = true,
+    this.showToolbarOnTap = false,
     this.autofocus = false,
     this.enableIMEPersonalizedLearning = false,
     this.enableInteractiveSelection = false,
@@ -318,6 +320,13 @@ class Pinput extends StatefulWidget {
 
   /// If true, paste button will appear on longPress event
   final bool toolbarEnabled;
+
+  /// If true, a single tap on an already-focused Pinput will toggle the context
+  /// menu on iOS, matching the standard [TextField] behavior.
+  ///
+  /// Defaults to false to preserve the existing Pinput behavior.
+  /// Only affects iOS; other platforms are unaffected.
+  final bool showToolbarOnTap;
 
   /// Whether show cursor or not
   /// Default cursor '|' or [cursor]
@@ -693,6 +702,13 @@ class Pinput extends StatefulWidget {
         'toolbarEnabled',
         toolbarEnabled,
         defaultValue: true,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty<bool>(
+        'showToolbarOnTap',
+        showToolbarOnTap,
+        defaultValue: false,
       ),
     );
     properties.add(

--- a/lib/src/pinput_state.dart
+++ b/lib/src/pinput_state.dart
@@ -32,6 +32,7 @@ class _PinputState extends State<Pinput>
   RestorableTextEditingController? _controller;
   FocusNode? _focusNode;
   bool _isHovering = false;
+  bool _isToolbarVisible = false;
   String? _validatorErrorText;
   SmsRetriever? _smsRetriever;
 
@@ -85,6 +86,7 @@ class _PinputState extends State<Pinput>
     }
 
     _effectiveFocusNode.canRequestFocus = isEnabled && widget.useNativeKeyboard;
+    _effectiveFocusNode.addListener(_handleFocusChange);
     _maybeInitSmartAuth();
     _maybeCheckClipboard();
     // https://github.com/Tkko/Flutter_Pinput/issues/89
@@ -191,6 +193,7 @@ class _PinputState extends State<Pinput>
 
   @override
   void dispose() {
+    _effectiveFocusNode.removeListener(_handleFocusChange);
     widget.controller?.removeListener(_handleTextEditingControllerChanges);
     _controller?.removeListener(_handleTextEditingControllerChanges);
     _controller?.dispose();
@@ -199,6 +202,12 @@ class _PinputState extends State<Pinput>
     // https://github.com/Tkko/Flutter_Pinput/issues/89
     _ambiguate(WidgetsBinding.instance)!.removeObserver(this);
     super.dispose();
+  }
+
+  void _handleFocusChange() {
+    if (!_effectiveFocusNode.hasFocus) {
+      _isToolbarVisible = false;
+    }
   }
 
   void _requestKeyboard() {
@@ -445,7 +454,12 @@ class _PinputState extends State<Pinput>
           backgroundCursorColor: Colors.transparent,
           selectionHeightStyle: BoxHeightStyle.tight,
           enableSuggestions: widget.enableSuggestions,
-          contextMenuBuilder: widget.contextMenuBuilder,
+          contextMenuBuilder: widget.contextMenuBuilder == null
+              ? null
+              : (context, editableTextState) {
+                  _isToolbarVisible = true;
+                  return widget.contextMenuBuilder!(context, editableTextState);
+                },
           obscuringCharacter: widget.obscuringCharacter,
           onAppPrivateCommand: widget.onAppPrivateCommand,
           onSelectionChanged: _handleSelectionChanged,

--- a/lib/src/widgets/_pinput_selection_gesture_detector_builder.dart
+++ b/lib/src/widgets/_pinput_selection_gesture_detector_builder.dart
@@ -18,8 +18,25 @@ class _PinputSelectionGestureDetectorBuilder
 
   @override
   void onSingleTapUp(details) {
-    super.onSingleTapUp(details);
-    editableText.hideToolbar();
+    // pinput's _handleSelectionChanged forcibly rewrites the selection on every
+    // tap, so the framework's toggleToolbar logic (which compares previousSelection
+    // == currentSelection) always falls into hideToolbar instead of toggling.
+    // We bypass super and manually implement the iOS toggle behavior.
+    if (delegate.selectionEnabled &&
+        _state.widget.showToolbarOnTap &&
+        defaultTargetPlatform == TargetPlatform.iOS &&
+        _state._effectiveFocusNode.hasFocus) {
+      if (_state._isToolbarVisible) {
+        _state._isToolbarVisible = false;
+        editableText.hideToolbar(false);
+      } else {
+        // toggleToolbar creates _selectionOverlay if null, which showToolbar() alone cannot.
+        editableText.toggleToolbar(false);
+      }
+    } else {
+      super.onSingleTapUp(details);
+      editableText.hideToolbar();
+    }
     _state._requestKeyboard();
     _state.widget.onTap?.call();
   }

--- a/test/pinput_test.dart
+++ b/test/pinput_test.dart
@@ -291,6 +291,54 @@ void main() {
     expect(tapCount, 3);
   });
 
+  testWidgets(
+    'onSingleTapUp shows context menu on second tap on iOS (already focused)',
+    (WidgetTester tester) async {
+      final focusNode = FocusNode();
+      int tapCount = 0;
+
+      await tester.pumpApp(
+        Pinput(
+          focusNode: focusNode,
+          showToolbarOnTap: true,
+          onTap: () => ++tapCount,
+        ),
+      );
+
+      // First tap: gains focus, no menu
+      await tester.tap(find.byType(EditableText));
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(tapCount, 1);
+      expect(focusNode.hasFocus, isTrue);
+
+      // Second tap while focused: onTap is still called
+      await tester.tap(find.byType(EditableText));
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(tapCount, 2);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+  );
+
+  testWidgets(
+    'onSingleTapUp on non-iOS still calls onTap',
+    (WidgetTester tester) async {
+      int tapCount = 0;
+
+      await tester.pumpApp(
+        Pinput(
+          onTap: () => ++tapCount,
+        ),
+      );
+
+      await tester.tap(find.byType(EditableText));
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.byType(EditableText));
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(tapCount, 2);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+  );
+
   testWidgets('onTap is not called, field is disabled',
       (WidgetTester tester) async {
     int tapCount = 0;


### PR DESCRIPTION
## Description

Adds `showToolbarOnTap` parameter to enable the standard iOS single-tap context menu behavior (Paste, Select All, etc.) when opted in.

Closes #235

## Motivation

As described in #235, on iOS, tapping an already-focused Pinput does not show the context menu — only a long press triggers it. The standard Flutter `TextField` toggles the context menu on a single tap when the field is already focused, so this PR adds an opt-in parameter to bring that behavior to Pinput.

I opted for a new parameter rather than changing the default behavior, since the current behavior may be intentional (e.g. to avoid accidental toolbar appearance during the initial focus transition). If there is a reason the existing behavior is by design, I'd love to hear it — happy to adjust the approach accordingly.

## Implementation notes

Simply removing `hideToolbar()` from `onSingleTapUp` was not sufficient due to two constraints I ran into:

1. `_handleSelectionChanged` rewrites the selection on every tap, so the framework's `toggleToolbar` condition (`previousSelection == currentSelection`) always resolves to `hideToolbar` rather than toggling.
2. `rendererIgnoresPointer: true` leaves `_selectionOverlay` as null, so `showToolbar()` does nothing in this case — `toggleToolbar()` is needed because it creates the overlay when null.

As a workaround, toolbar visibility is tracked with a manual `_isToolbarVisible` flag, since `EditableTextState.toolbarIsVisible` is not accessible from outside the framework.

## Testing

- [x] Verified on iOS simulator (Flutter 3.41.4, iOS 26.2)
- [x] Verified on Android device (Flutter 3.41.4, Android13) — behavior unchanged
- [x] `showToolbarOnTap: false` (default): long-press-only behavior unchanged
- [x] `showToolbarOnTap: true`: 1st tap focuses, 2nd tap shows menu, 3rd tap hides menu
- [x] Added widget tests for iOS and Android variants
- Note: actual context menu rendering is OS-level UI and cannot be verified in widget tests

### Demo (showToolbarOnTap: true, iOS)

> The demo was recorded with `showToolbarOnTap: true` set in the example app for
> verification purposes. This parameter is not changed in the example app in this PR.

|  | before | after |
| --- | --- | --- |
| iOS | <video src="https://github.com/user-attachments/assets/dab4fe6d-71c1-4c64-b62f-1cd56c0d5721"> | <video src="https://github.com/user-attachments/assets/99eef4b5-0f08-4f0f-832e-81419452a1d7"> |
| Android | <video src="https://github.com/user-attachments/assets/3679659f-e8c8-4786-a560-67b70544cfec"> | Behavior unchanged |

## Breaking Changes

None — `showToolbarOnTap` defaults to `false`, preserving existing behavior.

---

This is my first contribution to an open source project. If anything looks off — code style, approach, or anything else — please let me know and I'll be happy to update it.